### PR TITLE
Bugfixes: Moving Tabs and Removing Windows

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -84,7 +84,7 @@ export default function App() {
                         <TabSource tabName={"A"} heuristic="topleft" />
                         <TabSource tabName={"B"} heuristic="topleft" />
                         <TabSource tabName={"C"} heuristic="topleft" />
-                        <div>Add to Top Left: </div>
+                        <div>← Add to Top Left</div>
                     </div>
                     <AutoArrangeButton />
                     <div
@@ -98,7 +98,7 @@ export default function App() {
                             alignItems: "center",
                         }}
                     >
-                        <div>Add to Top Right</div>
+                        <div>Add to Top Right →</div>
                         <TabSource tabName={"D"} heuristic="topright" />
                         <TabSource tabName={"E"} heuristic="topright" />
                         <TabSource tabName={"F"} heuristic="topright" />

--- a/demo/Pane.tsx
+++ b/demo/Pane.tsx
@@ -20,7 +20,7 @@ export default function Pane({paneId}: {paneId: string}) {
                 style={{
                     fontSize: 24,
                     lineHeight: "32px",
-                    color: "#f5f5f4",
+                    color: "#cdd6f4",
                 }}
             >
                 {paneId}
@@ -29,7 +29,7 @@ export default function Pane({paneId}: {paneId: string}) {
                 style={{
                     fontSize: 20,
                     lineHeight: "28px",
-                    color: "#ef4444",
+                    color: "#a6d189",
                 }}
             >
                 Counter: {(counter / 10).toFixed(1)}s

--- a/src/LaymanReducer.ts
+++ b/src/LaymanReducer.ts
@@ -113,7 +113,7 @@ const moveTab = (layout: LaymanLayout, action: MoveTabAction) => {
     // Remove tab from original path if it came from within the layout
     // If it was added externally, action.path must be [-1], so we skip
     let removeTabLayout = layout;
-    if (!(action.path.length === 1 && action.path[0] != -1)) {
+    if (!(action.path.length === 1 && action.path[0] === -1)) {
         removeTabLayout = LaymanReducer(layout, {
             type: "removeTab",
             path: action.path,
@@ -207,7 +207,8 @@ const removeWindow = (layout: LaymanLayout, action: RemoveWindowAction) => {
                     return {
                         ...child,
                         viewPercent: child.viewPercent
-                            ? (child.viewPercent * grandparent.children.length) / (grandparent.children.length - 1)
+                            ? (child.viewPercent * grandparent.children.length) /
+                              (grandparent.children.length + onlyChild.children.length - 1)
                             : child.viewPercent,
                     };
                 }),
@@ -215,10 +216,10 @@ const removeWindow = (layout: LaymanLayout, action: RemoveWindowAction) => {
                     if (!child) return;
                     return {
                         ...child,
-                        viewPercent:
-                            child.viewPercent && parent.viewPercent
-                                ? (child.viewPercent * parent.viewPercent) / 100
-                                : child.viewPercent,
+                        viewPercent: child.viewPercent
+                            ? (child.viewPercent * onlyChild.children.length) /
+                              (grandparent.children.length + onlyChild.children.length - 1)
+                            : child.viewPercent,
                     };
                 }),
                 ...grandparent.children.slice(parentIndex + 1).map((child) => {
@@ -226,7 +227,8 @@ const removeWindow = (layout: LaymanLayout, action: RemoveWindowAction) => {
                     return {
                         ...child,
                         viewPercent: child.viewPercent
-                            ? (child.viewPercent * grandparent.children.length) / (grandparent.children.length - 1)
+                            ? (child.viewPercent * grandparent.children.length) /
+                              (grandparent.children.length + onlyChild.children.length - 1)
                             : child.viewPercent,
                     };
                 }),
@@ -330,9 +332,6 @@ const addWindow = (layout: LaymanLayout, action: AddWindowAction) => {
 const adjustPath = (layout: LaymanLayout, action: MoveWindowAction) => {
     const originalPath = action.path;
     const newPath = action.newPath;
-    console.log("originalPath: ", originalPath.join("."));
-    console.log("newPath: ", newPath.join("."));
-
     const commonLength = _.takeWhile(originalPath, (val, idx) => val === newPath[idx]).length;
 
     if (commonLength != originalPath.length - 1) {
@@ -416,8 +415,6 @@ const moveWindow = (layout: LaymanLayout, action: MoveWindowAction) => {
 
     // Handle removing window causes newPath to change
     const newPath = adjustPath(layout, action);
-
-    console.log("new newPath: ", newPath.join("."));
 
     if (action.placement === "center") {
         // Add all tabs


### PR DESCRIPTION
This PR implements the following bug fixes:

1. Moving tabs in the base layout no longer leaves the tab at its original location and properly removes them.
2. Removing windows that lead to the only child node merging with the grandparent node correctly modifies the split percentages of the new windows that are created.

This PR also adds some small stylistic changes:

1. Adjust text in the demo.
2. Change the color of the timer in the example Pane component.