### PR TITLE
fix: reject invalid removeWindow paths before mutating layout

### DIFF
--- a/src/LaymanReducer.ts
+++ b/src/LaymanReducer.ts
@@ -79,12 +79,21 @@ const treeAddTab = (layout: LaymanLayout, path: LaymanPath, tab: TabData): Layma
 
 const treeRemoveWindow = (layout: LaymanLayout, path: LaymanPath): LaymanLayout => {
     if (!layout) return layout;
+
+    if (!path.every((index) => Number.isInteger(index) && index >= 0)) {
+        return layout;
+    }
+
+    if (path.length === 0) {
+        return "tabs" in layout ? undefined : layout;
+    }
+
+    const target = getLayoutAtPath(layout, path);
+    if (!target || !("tabs" in target)) return layout;
+
     const parentPath = path.slice(0, -1);
     const parent: LaymanLayout = getLayoutAtPath(layout, parentPath);
-    if (!parent || !("children" in parent)) {
-        // Parent is the base layout, delete the layout
-        return undefined;
-    }
+    if (!parent || !("children" in parent)) return layout;
 
     // Get the removed window's split percentage so its remaining siblings can
     // be rescaled to fill the space it leaves behind.
@@ -569,8 +578,10 @@ const floatingSelectTab = (floatingWindows: FloatingWindowData[], floatingId: st
         fw.id === floatingId ? {...fw, selectedIndex: fw.tabs.findIndex((t) => t.id === tab.id)} : fw
     );
 
-const floatingRemoveWindow = (floatingWindows: FloatingWindowData[], floatingId: string): FloatingWindowData[] =>
-    floatingWindows.filter((fw) => fw.id !== floatingId);
+const floatingRemoveWindow = (floatingWindows: FloatingWindowData[], floatingId: string): FloatingWindowData[] => {
+    if (!floatingWindows.some((fw) => fw.id === floatingId)) return floatingWindows;
+    return floatingWindows.filter((fw) => fw.id !== floatingId);
+};
 
 // ---------------------------------------------------------------------------
 // Address-aware action handlers: these dispatch to the tree helpers or the
@@ -608,9 +619,11 @@ const selectTab = (state: LaymanState, action: SelectTabAction): LaymanState => 
 
 const removeWindow = (state: LaymanState, action: RemoveWindowAction): LaymanState => {
     if (isFloatingAddress(action.path)) {
-        return {...state, floatingWindows: floatingRemoveWindow(state.floatingWindows, action.path.floatingId)};
+        const floatingWindows = floatingRemoveWindow(state.floatingWindows, action.path.floatingId);
+        return floatingWindows === state.floatingWindows ? state : {...state, floatingWindows};
     }
-    return {...state, layout: treeRemoveWindow(state.layout, action.path)};
+    const layout = treeRemoveWindow(state.layout, action.path);
+    return layout === state.layout ? state : {...state, layout};
 };
 
 const addWindow = (state: LaymanState, action: AddWindowAction): LaymanState => {

--- a/tests/reducer.test.ts
+++ b/tests/reducer.test.ts
@@ -293,6 +293,37 @@ describe("removeWindow", () => {
         expect(result).toBeUndefined();
     });
 
+    it.each([[99], [-2], [0, 1]])("is a same-reference no-op for an invalid root-window path %j", (path) => {
+        const state: LaymanState = {layout: makeWindow(new TabData("Only")), floatingWindows: []};
+
+        expect(run(state, {type: "removeWindow", path})).toBe(state);
+    });
+
+    it("is a same-reference no-op for an out-of-range split child", () => {
+        const layout: LaymanNode = {
+            direction: "row",
+            children: [
+                {tabs: [new TabData("A")], selectedIndex: 0, viewPercent: 25},
+                {tabs: [new TabData("B")], selectedIndex: 0, viewPercent: 75},
+            ],
+        };
+        const state: LaymanState = {layout, floatingWindows: []};
+
+        const result = run(state, {type: "removeWindow", path: [2]});
+
+        expect(result).toBe(state);
+        expect((result.layout as LaymanNode).children.map((child) => child.viewPercent)).toEqual([25, 75]);
+    });
+
+    it("is a same-reference no-op for an unknown floating window", () => {
+        const state: LaymanState = {
+            layout: makeWindow(new TabData("Root")),
+            floatingWindows: [makeFloatingWindow("float-1", new TabData("Floater"))],
+        };
+
+        expect(run(state, {type: "removeWindow", path: {floatingId: "missing"}})).toBe(state);
+    });
+
     it("closes a floating window, leaving the tree untouched", () => {
         const layout = makeWindow(new TabData("Root"));
         const floatingWindow = makeFloatingWindow("float-1", new TabData("Floater"));


### PR DESCRIPTION
## Summary

- reject negative, stale, out-of-range, and split-node tiled paths before removal
- retain root deletion only for a root window at path []
- make unknown floating-window removal a same-reference no-op
- cover rejected inputs and preserved split percentages

## Validation

- npm test -- --run tests/reducer.test.ts
- NODE_OPTIONS=--localstorage-file=/tmp/react-layman-pr00-localstorage.json npm test
- npm run lint
- npm run build:lib

## Known baseline issue

Plain npm test on the current Node runtime still fails only in the existing localStorage test setup. The dedicated portability repair is planned as PR 04; this branch does not change persistence behavior.