### PR TITLE
fix: make unknown tab commands no-ops

### DIFF
--- a/src/LaymanReducer.ts
+++ b/src/LaymanReducer.ts
@@ -192,21 +192,15 @@ const treeRemoveTab = (layout: LaymanLayout, path: LaymanPath, tab: TabData): La
     const window: LaymanLayout = getLayoutAtPath(layout, path);
     if (!window || !("tabs" in window)) return layout;
 
-    // Create a new array of tabs without the removed tab
-    const updatedTabs = window.tabs.filter((t) => t.id !== tab.id);
+    const removedTabIndex = window.tabs.findIndex((candidate) => candidate.id === tab.id);
+    if (removedTabIndex === -1) return layout;
 
-    // Adjust selectedIndex only if the removed tab is
-    // to the left of the selected one
-    let updatedSelectedIndex = window.selectedIndex;
-    const removedTabIndex = window.tabs.indexOf(tab);
-
-    // `window.selectedIndex &&` intentionally skips this branch when selectedIndex
-    // is 0: if the removed tab was at or before index 0, it must have been the
-    // first tab, so the selection should stay at 0 (the new first tab) anyway,
-    // which is already the default value of updatedSelectedIndex.
-    if (window.selectedIndex && removedTabIndex <= window.selectedIndex) {
-        updatedSelectedIndex = Math.max(0, window.selectedIndex - 1);
-    }
+    const updatedTabs = window.tabs.filter((_candidate, index) => index !== removedTabIndex);
+    const selectedIndex = window.selectedIndex ?? 0;
+    const updatedSelectedIndex =
+        removedTabIndex < selectedIndex
+            ? selectedIndex - 1
+            : Math.min(selectedIndex, updatedTabs.length - 1);
 
     // If no more tabs exist, remove the window itself
     if (updatedTabs.length === 0) {
@@ -231,10 +225,12 @@ const treeSelectTab = (layout: LaymanLayout, path: LaymanPath, tab: TabData): La
     const window: LaymanLayout = getLayoutAtPath(layout, path);
     if (!window || !("tabs" in window)) return layout;
 
-    // Update selectedIndex in the window
+    const selectedIndex = window.tabs.findIndex((candidate) => candidate.id === tab.id);
+    if (selectedIndex === -1 || selectedIndex === window.selectedIndex) return layout;
+
     const updatedLayout = {
         ...window,
-        selectedIndex: window.tabs.findIndex((t) => t.id === tab.id),
+        selectedIndex,
     };
 
     if (path.length == 0) {
@@ -546,28 +542,35 @@ const floatingRemoveTab = (
     const floatingWindow = floatingWindows.find((fw) => fw.id === floatingId);
     if (!floatingWindow) return floatingWindows;
 
-    const updatedTabs = floatingWindow.tabs.filter((t) => t.id !== tab.id);
+    const removedTabIndex = floatingWindow.tabs.findIndex((candidate) => candidate.id === tab.id);
+    if (removedTabIndex === -1) return floatingWindows;
+
+    const updatedTabs = floatingWindow.tabs.filter((_candidate, index) => index !== removedTabIndex);
 
     // If no tabs remain, the floating window closes itself.
     if (updatedTabs.length === 0) {
         return floatingWindows.filter((fw) => fw.id !== floatingId);
     }
 
-    let updatedSelectedIndex = floatingWindow.selectedIndex;
-    const removedTabIndex = floatingWindow.tabs.indexOf(tab);
-    if (removedTabIndex <= floatingWindow.selectedIndex) {
-        updatedSelectedIndex = Math.max(0, floatingWindow.selectedIndex - 1);
-    }
+    const updatedSelectedIndex =
+        removedTabIndex < floatingWindow.selectedIndex
+            ? floatingWindow.selectedIndex - 1
+            : Math.min(floatingWindow.selectedIndex, updatedTabs.length - 1);
 
     return floatingWindows.map((fw) =>
         fw.id === floatingId ? {...fw, tabs: updatedTabs, selectedIndex: updatedSelectedIndex} : fw
     );
 };
 
-const floatingSelectTab = (floatingWindows: FloatingWindowData[], floatingId: string, tab: TabData): FloatingWindowData[] =>
-    floatingWindows.map((fw) =>
-        fw.id === floatingId ? {...fw, selectedIndex: fw.tabs.findIndex((t) => t.id === tab.id)} : fw
-    );
+const floatingSelectTab = (floatingWindows: FloatingWindowData[], floatingId: string, tab: TabData): FloatingWindowData[] => {
+    const floatingWindow = floatingWindows.find((fw) => fw.id === floatingId);
+    if (!floatingWindow) return floatingWindows;
+
+    const selectedIndex = floatingWindow.tabs.findIndex((candidate) => candidate.id === tab.id);
+    if (selectedIndex === -1 || selectedIndex === floatingWindow.selectedIndex) return floatingWindows;
+
+    return floatingWindows.map((fw) => (fw.id === floatingId ? {...fw, selectedIndex} : fw));
+};
 
 const floatingRemoveWindow = (floatingWindows: FloatingWindowData[], floatingId: string): FloatingWindowData[] =>
     floatingWindows.filter((fw) => fw.id !== floatingId);
@@ -588,22 +591,20 @@ const addTab = (state: LaymanState, action: AddTabAction): LaymanState => {
 
 const removeTab = (state: LaymanState, action: RemoveTabAction): LaymanState => {
     if (isFloatingAddress(action.path)) {
-        return {
-            ...state,
-            floatingWindows: floatingRemoveTab(state.floatingWindows, action.path.floatingId, action.tab),
-        };
+        const floatingWindows = floatingRemoveTab(state.floatingWindows, action.path.floatingId, action.tab);
+        return floatingWindows === state.floatingWindows ? state : {...state, floatingWindows};
     }
-    return {...state, layout: treeRemoveTab(state.layout, action.path, action.tab)};
+    const layout = treeRemoveTab(state.layout, action.path, action.tab);
+    return layout === state.layout ? state : {...state, layout};
 };
 
 const selectTab = (state: LaymanState, action: SelectTabAction): LaymanState => {
     if (isFloatingAddress(action.path)) {
-        return {
-            ...state,
-            floatingWindows: floatingSelectTab(state.floatingWindows, action.path.floatingId, action.tab),
-        };
+        const floatingWindows = floatingSelectTab(state.floatingWindows, action.path.floatingId, action.tab);
+        return floatingWindows === state.floatingWindows ? state : {...state, floatingWindows};
     }
-    return {...state, layout: treeSelectTab(state.layout, action.path, action.tab)};
+    const layout = treeSelectTab(state.layout, action.path, action.tab);
+    return layout === state.layout ? state : {...state, layout};
 };
 
 const removeWindow = (state: LaymanState, action: RemoveWindowAction): LaymanState => {

--- a/tests/reducer.test.ts
+++ b/tests/reducer.test.ts
@@ -150,6 +150,61 @@ describe("removeTab", () => {
 
         expect(result.floatingWindows).toEqual([]);
     });
+
+    it("is a same-reference no-op when a tiled window does not contain the tab ID", () => {
+        const state: LaymanState = {
+            layout: {tabs: [new TabData("A"), new TabData("B")], selectedIndex: 1},
+            floatingWindows: [],
+        };
+        const unknown = new TabData("Unknown");
+
+        expect(run(state, {type: "removeTab", path: [], tab: unknown})).toBe(state);
+        expect(run(state, {type: "selectTab", path: [], tab: unknown})).toBe(state);
+    });
+
+    it("removes the stored tiled tab when a separate object has the same ID", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const c = new TabData("C");
+        const actionTab = new TabData("Stale copy");
+        actionTab.id = b.id;
+        const state: LaymanState = {layout: {tabs: [a, b, c], selectedIndex: 2}, floatingWindows: []};
+
+        const result = run(state, {type: "removeTab", path: [], tab: actionTab});
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([a, c]);
+        expect((result.layout as LaymanWindow).selectedIndex).toBe(1);
+    });
+
+    it("keeps selection within bounds when the selected last tiled tab is removed", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const c = new TabData("C");
+        const state: LaymanState = {layout: {tabs: [a, b, c], selectedIndex: 2}, floatingWindows: []};
+
+        const result = run(state, {type: "removeTab", path: [], tab: c});
+
+        expect((result.layout as LaymanWindow).selectedIndex).toBe(1);
+    });
+
+    it("enforces the same membership rules for floating windows", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const c = new TabData("C");
+        const actionTab = new TabData("Stale copy");
+        actionTab.id = b.id;
+        const floatingWindow = {...makeFloatingWindow("float-1", a, b, c), selectedIndex: 2};
+        const state: LaymanState = {layout: undefined, floatingWindows: [floatingWindow]};
+        const unknown = new TabData("Unknown");
+
+        expect(run(state, {type: "removeTab", path: {floatingId: "float-1"}, tab: unknown})).toBe(state);
+        expect(run(state, {type: "selectTab", path: {floatingId: "float-1"}, tab: unknown})).toBe(state);
+
+        const result = run(state, {type: "removeTab", path: {floatingId: "float-1"}, tab: actionTab});
+
+        expect(result.floatingWindows[0].tabs).toEqual([a, c]);
+        expect(result.floatingWindows[0].selectedIndex).toBe(1);
+    });
 });
 
 describe("moveTab", () => {


### PR DESCRIPTION
## Summary

- resolve tiled and floating tabs by ID before selecting or removing them
- reject unknown tab IDs without changing state or selection
- use the stored tab position when repairing selection after removal
- preserve same-reference no-op behavior for rejected commands

## Validation

- npm test -- --run tests/reducer.test.ts
- NODE_OPTIONS=--localstorage-file=/tmp/react-layman-pr01-localstorage.json npm test
- npx --no-install tsc --noEmit
- npm run lint
- npm run build:lib

## Known baseline issue

Plain npm test on the current Node runtime still fails only in the existing localStorage test setup. The dedicated portability repair is planned as PR 04; this branch does not change persistence behavior.