### PR TITLE
fix: make moveTab validate before committing source removal

### DIFF
--- a/src/LaymanReducer.ts
+++ b/src/LaymanReducer.ts
@@ -17,6 +17,7 @@ import {
     RemoveWindowAction,
     SelectTabAction,
     SetFloatingWindowPositionAction,
+    WindowAddress,
 } from "./types";
 import {TabData} from "./TabData";
 import {deepClone, isFloatingAddress} from "./utils";
@@ -622,31 +623,88 @@ const addWindow = (state: LaymanState, action: AddWindowAction): LaymanState => 
     return {...state, layout: treeAddWindow(state.layout, action.path, action.window, action.placement)};
 };
 
+type ResolvedTabSource =
+    | {kind: "external"; tab: TabData}
+    | {kind: "tree"; path: LaymanPath; tab: TabData; removesWindow: boolean}
+    | {kind: "floating"; floatingId: string; tab: TabData};
+
+const isExternalTabSource = (path: WindowAddress): path is LaymanPath =>
+    Array.isArray(path) && path.length === 1 && path[0] === -1;
+
+const resolveTabSource = (state: LaymanState, path: WindowAddress, requestedTab: TabData): ResolvedTabSource | undefined => {
+    if (isExternalTabSource(path)) return {kind: "external", tab: requestedTab};
+
+    if (isFloatingAddress(path)) {
+        const floatingWindow = state.floatingWindows.find((window) => window.id === path.floatingId);
+        const tab = floatingWindow?.tabs.find((candidate) => candidate.id === requestedTab.id);
+        return tab ? {kind: "floating", floatingId: path.floatingId, tab} : undefined;
+    }
+
+    const window = getLayoutAtPath(state.layout, path);
+    if (!window || !("tabs" in window)) return undefined;
+    const tab = window.tabs.find((candidate) => candidate.id === requestedTab.id);
+    return tab ? {kind: "tree", path, tab, removesWindow: window.tabs.length === 1} : undefined;
+};
+
+const isValidTabPlacement = (placement: MoveTabAction["placement"]): boolean =>
+    placement === "top" || placement === "bottom" || placement === "left" || placement === "right" || placement === "center";
+
+const hasTabDestination = (state: LaymanState, path: WindowAddress): boolean => {
+    if (isFloatingAddress(path)) return state.floatingWindows.some((window) => window.id === path.floatingId);
+
+    const window = getLayoutAtPath(state.layout, path);
+    return Boolean(window && "tabs" in window);
+};
+
+const isTabSelfTarget = (source: ResolvedTabSource, path: WindowAddress): boolean => {
+    if (source.kind === "tree" && Array.isArray(path)) {
+        return source.path.length === path.length && source.path.every((segment, index) => segment === path[index]);
+    }
+    return source.kind === "floating" && isFloatingAddress(path) && source.floatingId === path.floatingId;
+};
+
 const moveTab = (state: LaymanState, action: MoveTabAction): LaymanState => {
-    // Remove the tab from its source, unless it came from outside the
-    // layout entirely (external tab sources use the `[-1]` sentinel path).
-    const isExternalSource = Array.isArray(action.path) && action.path.length === 1 && action.path[0] === -1;
-    const working = isExternalSource ? state : removeTab(state, {type: "removeTab", path: action.path, tab: action.tab});
+    const source = resolveTabSource(state, action.path, action.tab);
+    if (!source || !isValidTabPlacement(action.placement) || !hasTabDestination(state, action.newPath)) return state;
+
+    // A tab is already in this destination. Edge moves deliberately remain
+    // supported: after removal, they split the remaining destination window.
+    if (isTabSelfTarget(source, action.newPath) && action.placement === "center") return state;
+
+    if (isFloatingAddress(action.newPath) && action.placement !== "center") return state;
+
+    const working =
+        source.kind === "external"
+            ? state
+            : removeTab(state, {
+                  type: "removeTab",
+                  path: source.kind === "tree" ? source.path : {floatingId: source.floatingId},
+                  tab: source.tab,
+              });
 
     if (isFloatingAddress(action.newPath)) {
         const floatingId = action.newPath.floatingId;
-        // moveTab only ever merges into an *existing* floating window; to
-        // float a tab out into a brand new floating window, float the whole
-        // window (see moveWindow) instead.
-        if (!working.floatingWindows.some((fw) => fw.id === floatingId)) return working;
-        return {...working, floatingWindows: floatingAddTab(working.floatingWindows, floatingId, action.tab)};
+        if (!working.floatingWindows.some((fw) => fw.id === floatingId)) return state;
+        return {...working, floatingWindows: floatingAddTab(working.floatingWindows, floatingId, source.tab)};
     }
 
-    if (!working.layout) return working;
-    const destWindow = getLayoutAtPath(working.layout, action.newPath);
-    if (!destWindow || !("tabs" in destWindow)) return working;
+    if (!working.layout) return state;
+    const destinationPath =
+        source.kind === "tree" && source.removesWindow
+            ? adjustPath(state.layout, source.path, action.newPath)
+            : action.newPath;
+    const destinationWindow = getLayoutAtPath(working.layout, destinationPath);
+    if (!destinationWindow || !("tabs" in destinationWindow)) return state;
 
     if (action.placement === "center") {
-        return {...working, layout: treeAddTab(working.layout, action.newPath, action.tab)};
+        return {...working, layout: treeAddTab(working.layout, destinationPath, source.tab)};
     }
+
+    const layout = treeAddWindow(working.layout, destinationPath, {tabs: [source.tab], selectedIndex: 0}, action.placement);
+    if (layout === working.layout) return state;
     return {
         ...working,
-        layout: treeAddWindow(working.layout, action.newPath, {tabs: [action.tab], selectedIndex: 0}, action.placement),
+        layout,
     };
 };
 

--- a/tests/reducer.test.ts
+++ b/tests/reducer.test.ts
@@ -253,6 +253,140 @@ describe("moveTab", () => {
         expect((result.layout as LaymanWindow).tabs).toEqual([a, b]);
         expect(result.floatingWindows[0].tabs.map((t) => t.name)).toEqual(["Stays"]);
     });
+
+    it("is a same-reference no-op when the destination is invalid", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const state: LaymanState = {layout: makeRowOfTwo(a, b), floatingWindows: []};
+
+        const result = run(state, {type: "moveTab", path: [0], newPath: [99], tab: a, placement: "center"});
+
+        expect(result).toBe(state);
+    });
+
+    it("keeps a valid sibling destination when the source branch collapses", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const state: LaymanState = {layout: makeRowOfTwo(a, b), floatingWindows: []};
+
+        const result = run(state, {type: "moveTab", path: [0], newPath: [1], tab: a, placement: "center"});
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([b, a]);
+    });
+
+    it("is a same-reference no-op when the source tab is missing", () => {
+        const state: LaymanState = {layout: makeWindow(new TabData("A"), new TabData("B")), floatingWindows: []};
+
+        expect(
+            run(state, {
+                type: "moveTab",
+                path: [],
+                newPath: [],
+                tab: new TabData("Missing"),
+                placement: "center",
+            })
+        ).toBe(state);
+    });
+
+    it("moves the stored source tab instead of a forged action payload", () => {
+        const sourceTab = new TabData("Stored source", {source: true});
+        const stays = new TabData("Stays");
+        const forgedTab = new TabData("Forged", {source: false});
+        forgedTab.id = sourceTab.id;
+        const floatingWindow = makeFloatingWindow("float-1", new TabData("Floating"));
+        const state: LaymanState = {layout: makeWindow(sourceTab, stays), floatingWindows: [floatingWindow]};
+
+        const result = run(state, {
+            type: "moveTab",
+            path: [],
+            newPath: {floatingId: "float-1"},
+            tab: forgedTab,
+            placement: "center",
+        });
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([stays]);
+        expect(result.floatingWindows[0].tabs[1]).toBe(sourceTab);
+    });
+
+    it("is a same-reference no-op for a missing floating destination", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const state: LaymanState = {layout: makeWindow(a, b), floatingWindows: []};
+
+        const result = run(state, {
+            type: "moveTab",
+            path: [],
+            newPath: {floatingId: "missing"},
+            tab: b,
+            placement: "center",
+        });
+
+        expect(result).toBe(state);
+    });
+
+    it("rejects an edge placement into a floating destination", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const state: LaymanState = {
+            layout: makeWindow(a, b),
+            floatingWindows: [makeFloatingWindow("float-1", new TabData("Floating"))],
+        };
+
+        const result = run(state, {
+            type: "moveTab",
+            path: [],
+            newPath: {floatingId: "float-1"},
+            tab: b,
+            placement: "left",
+        });
+
+        expect(result).toBe(state);
+    });
+
+    it("moves a floating source tab into a tiled destination", () => {
+        const root = new TabData("Root");
+        const sourceTab = new TabData("Floating");
+        const stays = new TabData("Stays");
+        const state: LaymanState = {
+            layout: makeWindow(root),
+            floatingWindows: [makeFloatingWindow("float-1", sourceTab, stays)],
+        };
+
+        const result = run(state, {
+            type: "moveTab",
+            path: {floatingId: "float-1"},
+            newPath: [],
+            tab: sourceTab,
+            placement: "center",
+        });
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([root, sourceTab]);
+        expect(result.floatingWindows[0].tabs).toEqual([stays]);
+    });
+
+    it("inserts an external source tab without removing a layout tab", () => {
+        const existing = new TabData("Existing");
+        const external = new TabData("External");
+        const state: LaymanState = {layout: makeWindow(existing), floatingWindows: []};
+
+        const result = run(state, {
+            type: "moveTab",
+            path: [-1],
+            newPath: [],
+            tab: external,
+            placement: "center",
+        });
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([existing, external]);
+    });
+
+    it("is a no-op for a self-targeting center move", () => {
+        const a = new TabData("A");
+        const b = new TabData("B");
+        const state: LaymanState = {layout: makeWindow(a, b), floatingWindows: []};
+
+        expect(run(state, {type: "moveTab", path: [], newPath: [], tab: b, placement: "center"})).toBe(state);
+    });
 });
 
 describe("removeWindow", () => {


### PR DESCRIPTION
## Summary

- Validate tab source, destination, and placement before a source mutation.
- Move the stored tab object, not an action payload that reuses its ID.
- Adjust a tree destination only when removing the source tab collapses its window; preserve an explicit self-edge split and make self-center moves no-ops.
- Keep the legacy external [-1] source at the public boundary but represent it explicitly in the reducer.

## Validation

- npm test -- --run tests/reducer.test.ts (42 passed)
- NODE_OPTIONS=--localstorage-file=/tmp/react-layman-pr02-localstorage.json npm test (79 passed)
- npx --no-install tsc --noEmit
- npm run lint
- npm run build:lib

Plain npm test still has the known Node 26 localStorage setup failure in persistence tests. PR 04 owns that portable test setup.