### PR TITLE
fix: make moveWindow source-authoritative and atomic

### DIFF
--- a/src/LaymanReducer.ts
+++ b/src/LaymanReducer.ts
@@ -17,6 +17,7 @@ import {
     RemoveWindowAction,
     SelectTabAction,
     SetFloatingWindowPositionAction,
+    WindowAddress,
 } from "./types";
 import {TabData} from "./TabData";
 import {deepClone, isFloatingAddress} from "./utils";
@@ -650,63 +651,129 @@ const moveTab = (state: LaymanState, action: MoveTabAction): LaymanState => {
     };
 };
 
-const moveWindow = (state: LaymanState, action: MoveWindowAction): LaymanState => {
-    // Step 1: remove the window from its source, and note whether the
-    // destination path needs adjusting for shifted tree indices (only
-    // relevant when the window was removed from *within* the same tree).
-    let working: LaymanState;
-    let sourceWasTreePath: LaymanPath | undefined;
-    if (isFloatingAddress(action.path)) {
-        working = {...state, floatingWindows: floatingRemoveWindow(state.floatingWindows, action.path.floatingId)};
-    } else {
-        const window: LaymanLayout = getLayoutAtPath(state.layout, action.path);
-        if (!window || !("tabs" in window)) return state;
-        working = {...state, layout: treeRemoveWindow(state.layout, action.path)};
-        sourceWasTreePath = action.path;
+type ResolvedWindowSource =
+    | {kind: "tree"; path: LaymanPath; window: LaymanWindow}
+    | {kind: "floating"; floatingId: string; window: FloatingWindowData};
+
+const resolveWindowSource = (state: LaymanState, path: WindowAddress): ResolvedWindowSource | undefined => {
+    if (isFloatingAddress(path)) {
+        const window = state.floatingWindows.find((candidate) => candidate.id === path.floatingId);
+        return window ? {kind: "floating", floatingId: path.floatingId, window} : undefined;
     }
 
-    // Step 2a: destination is a floating window (new or existing).
+    const window = getLayoutAtPath(state.layout, path);
+    return window && "tabs" in window ? {kind: "tree", path, window} : undefined;
+};
+
+const isValidWindowPlacement = (placement: MoveWindowAction["placement"]): boolean =>
+    placement === "top" || placement === "bottom" || placement === "left" || placement === "right" || placement === "center";
+
+const isValidFloatingId = (id: string): boolean => typeof id === "string" && id.trim().length > 0;
+
+const isPathWithin = (path: LaymanPath, ancestor: LaymanPath): boolean =>
+    ancestor.length <= path.length && ancestor.every((segment, index) => path[index] === segment);
+
+const hasValidFloatingPosition = (position: MoveWindowAction["position"]): boolean =>
+    Boolean(
+        position &&
+            Number.isFinite(position.top) &&
+            Number.isFinite(position.left) &&
+            Number.isFinite(position.width) &&
+            Number.isFinite(position.height) &&
+            position.width > 0 &&
+            position.height > 0
+    );
+
+const hasValidWindowTreeDestination = (
+    layout: LaymanLayout,
+    path: LaymanPath,
+    placement: MoveWindowAction["placement"]
+): boolean => {
+    if (!layout) return path.length === 0;
+
+    const destination = getLayoutAtPath(layout, path);
+    if (destination && "tabs" in destination) return true;
+
+    // An edge drop at root may extend or wrap a split root. Center drops need
+    // a real tab strip to merge with.
+    return path.length === 0 && placement !== "center" && "children" in layout;
+};
+
+const isValidWindowMove = (state: LaymanState, source: ResolvedWindowSource, action: MoveWindowAction): boolean => {
+    if (!isValidWindowPlacement(action.placement)) return false;
+
     if (isFloatingAddress(action.newPath)) {
-        const floatingId = action.newPath.floatingId;
-        const existing = working.floatingWindows.find((fw) => fw.id === floatingId);
+        const floatingDestination = action.newPath;
+        if (!isValidFloatingId(floatingDestination.floatingId)) return false;
+        if (action.placement !== "center") return false;
+        if (source.kind === "floating" && source.floatingId === floatingDestination.floatingId) return false;
+
+        return (
+            state.floatingWindows.some((window) => window.id === floatingDestination.floatingId) ||
+            hasValidFloatingPosition(action.position)
+        );
+    }
+
+    if (source.kind === "tree" && isPathWithin(action.newPath, source.path)) return false;
+    return hasValidWindowTreeDestination(state.layout, action.newPath, action.placement);
+};
+
+const asLaymanWindow = (source: ResolvedWindowSource): LaymanWindow => ({
+    tabs: source.window.tabs,
+    selectedIndex: source.window.selectedIndex,
+    ...(source.kind === "tree" && source.window.viewPercent !== undefined ? {viewPercent: source.window.viewPercent} : {}),
+});
+
+const moveWindow = (state: LaymanState, action: MoveWindowAction): LaymanState => {
+    const source = resolveWindowSource(state, action.path);
+    if (!source || !isValidWindowMove(state, source, action)) return state;
+
+    const working =
+        source.kind === "tree"
+            ? {...state, layout: treeRemoveWindow(state.layout, source.path)}
+            : {...state, floatingWindows: floatingRemoveWindow(state.floatingWindows, source.floatingId)};
+    const sourceWindow = asLaymanWindow(source);
+
+    if (isFloatingAddress(action.newPath)) {
+        const floatingDestination = action.newPath;
+        const existing = working.floatingWindows.find((window) => window.id === floatingDestination.floatingId);
         if (existing) {
-            // Merge tabs into the already-floating destination. Floating
-            // windows are single-pane, so `placement` doesn't matter here.
             return {
                 ...working,
-                floatingWindows: working.floatingWindows.map((fw) =>
-                    fw.id === floatingId ? {...fw, tabs: [...fw.tabs, ...action.window.tabs]} : fw
+                floatingWindows: working.floatingWindows.map((window) =>
+                    window.id === existing.id ? {...window, tabs: [...window.tabs, ...sourceWindow.tabs]} : window
                 ),
             };
         }
-        // No floating window with this id exists yet: this is a "float this
-        // window" move. `position` must be supplied to seed its rect.
-        if (!action.position) return state;
-        const newFloatingWindow: FloatingWindowData = {
-            id: floatingId,
-            tabs: action.window.tabs,
-            selectedIndex: action.window.selectedIndex ?? 0,
-            position: action.position,
-            zIndex: nextFloatingZIndex(working.floatingWindows),
+
+        // Validation above proves a new floating destination has a usable
+        // position. This branch cannot leave the source partially moved.
+        return {
+            ...working,
+            floatingWindows: [
+                ...working.floatingWindows,
+                {
+                    id: floatingDestination.floatingId,
+                    tabs: sourceWindow.tabs,
+                    selectedIndex: sourceWindow.selectedIndex ?? 0,
+                    position: action.position!,
+                    zIndex: nextFloatingZIndex(working.floatingWindows),
+                },
+            ],
         };
-        return {...working, floatingWindows: [...working.floatingWindows, newFloatingWindow]};
     }
 
-    // Step 2b: destination is a tree path. Removing a tree-sourced window can
-    // shift sibling indices, so the destination path needs adjusting; a
-    // floating source never shifts tree indices.
-    const destPath = sourceWasTreePath
-        ? adjustPath(state.layout, sourceWasTreePath, action.newPath)
-        : action.newPath;
-
+    const destinationPath = source.kind === "tree" ? adjustPath(state.layout, source.path, action.newPath) : action.newPath;
     if (action.placement === "center") {
-        let updatedLayout = deepClone(working.layout);
-        action.window.tabs.forEach((tab) => {
-            updatedLayout = treeAddTab(updatedLayout, destPath, tab);
-        });
-        return {...working, layout: updatedLayout};
+        const layout = sourceWindow.tabs.reduce(
+            (nextLayout, tab) => treeAddTab(nextLayout, destinationPath, tab),
+            working.layout
+        );
+        return {...working, layout};
     }
-    return {...working, layout: treeAddWindow(working.layout, destPath, action.window, action.placement)};
+
+    const layout = treeAddWindow(working.layout, destinationPath, sourceWindow, action.placement);
+    return layout === working.layout ? state : {...working, layout};
 };
 
 const setFloatingWindowPosition = (state: LaymanState, action: SetFloatingWindowPositionAction): LaymanState => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,11 @@ export interface RemoveWindowAction extends BaseLaymanLayoutAction {
 
 export interface MoveWindowAction extends BaseLaymanLayoutAction {
     type: "moveWindow";
+    /**
+     * @deprecated The reducer resolves the source window from `path` and
+     * ignores this payload. It remains required for source compatibility and
+     * will be removed from the public action in a later release.
+     */
     window: LaymanWindow;
     newPath: WindowAddress;
     placement: "top" | "bottom" | "left" | "right" | "center";

--- a/tests/moveWindow.test.ts
+++ b/tests/moveWindow.test.ts
@@ -1,0 +1,143 @@
+import {describe, expect, it} from "vitest";
+import {LaymanReducer} from "../src/LaymanReducer";
+import {TabData} from "../src/TabData";
+import {FloatingWindowData, LaymanNode, LaymanState, LaymanWindow} from "../src/types";
+
+const windowWith = (...tabs: TabData[]): LaymanWindow => ({tabs, selectedIndex: 0});
+
+const rowOfTwo = (left: TabData, right: TabData): LaymanNode => ({
+    direction: "row",
+    children: [windowWith(left), windowWith(right)],
+});
+
+const floatingWindow = (id: string, ...tabs: TabData[]): FloatingWindowData => ({
+    id,
+    tabs,
+    selectedIndex: 0,
+    position: {top: 10, left: 10, width: 300, height: 200},
+    zIndex: 30,
+});
+
+describe("moveWindow atomicity", () => {
+    it("preserves the complete state for an invalid tiled destination", () => {
+        const left = new TabData("Left");
+        const right = new TabData("Right");
+        const state: LaymanState = {layout: rowOfTwo(left, right), floatingWindows: []};
+
+        const result = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: [99],
+            window: windowWith(left),
+            placement: "center",
+        });
+
+        expect(result).toBe(state);
+    });
+
+    it("preserves the complete state for an invalid floating destination", () => {
+        const left = new TabData("Left");
+        const right = new TabData("Right");
+        const state: LaymanState = {layout: rowOfTwo(left, right), floatingWindows: []};
+
+        const result = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: {floatingId: "new-float"},
+            window: windowWith(left),
+            placement: "center",
+        });
+
+        const missingId = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: {floatingId: ""},
+            window: windowWith(left),
+            placement: "center",
+            position: {top: 0, left: 0, width: 100, height: 100},
+        });
+
+        expect(result).toBe(state);
+        expect(missingId).toBe(state);
+    });
+
+    it("moves the stored source window instead of a stale action payload", () => {
+        const sourceTab = new TabData("Stored source");
+        const targetTab = new TabData("Target");
+        const forgedTab = new TabData("Forged");
+        const state: LaymanState = {layout: rowOfTwo(sourceTab, targetTab), floatingWindows: []};
+
+        const result = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: [1],
+            window: windowWith(forgedTab),
+            placement: "center",
+        });
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([targetTab, sourceTab]);
+        expect((result.layout as LaymanWindow).tabs).not.toContain(forgedTab);
+    });
+
+    it("adjusts a sibling destination after removing the source window", () => {
+        const left = new TabData("Left");
+        const right = new TabData("Right");
+        const state: LaymanState = {layout: rowOfTwo(left, right), floatingWindows: []};
+
+        const result = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: [1],
+            window: windowWith(left),
+            placement: "center",
+        });
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([right, left]);
+    });
+
+    it("uses the resolved source tabs for a new floating window", () => {
+        const sourceTab = new TabData("Stored source");
+        const right = new TabData("Right");
+        const forgedTab = new TabData("Forged");
+        const position = {top: 5, left: 8, width: 320, height: 240};
+        const state: LaymanState = {layout: rowOfTwo(sourceTab, right), floatingWindows: []};
+
+        const result = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: {floatingId: "new-float"},
+            window: windowWith(forgedTab),
+            placement: "center",
+            position,
+        });
+
+        expect((result.layout as LaymanWindow).tabs).toEqual([right]);
+        expect(result.floatingWindows).toHaveLength(1);
+        expect(result.floatingWindows[0]).toMatchObject({id: "new-float", tabs: [sourceTab], position});
+    });
+
+    it("rejects a floating edge drop and a destination inside the source subtree", () => {
+        const left = new TabData("Left");
+        const right = new TabData("Right");
+        const float = floatingWindow("float-1", new TabData("Floating"));
+        const state: LaymanState = {layout: rowOfTwo(left, right), floatingWindows: [float]};
+
+        const floatingEdge = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: {floatingId: "float-1"},
+            window: windowWith(left),
+            placement: "left",
+        });
+        const selfTarget = LaymanReducer(state, {
+            type: "moveWindow",
+            path: [0],
+            newPath: [0],
+            window: windowWith(left),
+            placement: "right",
+        });
+
+        expect(floatingEdge).toBe(state);
+        expect(selfTarget).toBe(state);
+    });
+});


### PR DESCRIPTION
## Summary

- Resolve and validate both move endpoints before mutating the source state.
- Move the stored source window and ignore the deprecated caller-supplied window payload.
- Reject stale tiled paths, malformed or unseeded new floating destinations, unsupported floating edge drops, and self-targeting tree moves.
- Preserve valid tree, floating, and root-edge transfers while adjusting a destination after source removal.

## Validation

- npm test -- --run tests/moveWindow.test.ts tests/reducer.test.ts (39 passed)
- NODE_OPTIONS=--localstorage-file=/tmp/react-layman-pr03-localstorage.json npm test (76 passed)
- npx --no-install tsc --noEmit
- npm run lint
- npm run build:lib

Plain npm test has the known Node 26 localStorage setup failure in persistence tests. PR 04 owns that portable test setup.