### PR TITLE
test: make localStorage tests independent of Node runtime flags

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,26 @@
+---
+name: Verify
+
+"on":
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    name: Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20.19.x, 22.x, 24.x]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
+      - run: npm run build:lib

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     ],
     "author": "Jeshwin Prince",
     "license": "MIT",
+    "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+    },
     "bugs": {
         "url": "https://github.com/Jeshwin/react-layman/issues"
     },

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1,0 +1,12 @@
+import {describe, expect, it} from "vitest";
+
+describe.sequential("test localStorage", () => {
+    it("writes a value", () => {
+        window.localStorage.setItem("set-by-previous-test", "present");
+        expect(window.localStorage.getItem("set-by-previous-test")).toBe("present");
+    });
+
+    it("does not expose values from a previous test", () => {
+        expect(window.localStorage.getItem("set-by-previous-test")).toBeNull();
+    });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,38 @@
+import {beforeEach} from "vitest";
+
+class MemoryStorage implements Storage {
+    private values = new Map<string, string>();
+
+    get length(): number {
+        return this.values.size;
+    }
+
+    clear(): void {
+        this.values.clear();
+    }
+
+    getItem(key: string): string | null {
+        return this.values.get(key) ?? null;
+    }
+
+    key(index: number): string | null {
+        return [...this.values.keys()][index] ?? null;
+    }
+
+    removeItem(key: string): void {
+        this.values.delete(key);
+    }
+
+    setItem(key: string, value: string): void {
+        this.values.set(key, value);
+    }
+}
+
+const storage = new MemoryStorage();
+
+Object.defineProperty(window, "localStorage", {configurable: true, value: storage});
+Object.defineProperty(globalThis, "localStorage", {configurable: true, value: storage});
+
+beforeEach(() => {
+    storage.clear();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,11 @@ export default defineConfig({
         environment: "jsdom",
         globals: true,
         include: ["tests/**/*.test.ts"],
+        setupFiles: ["./tests/setup.ts"],
+        environmentOptions: {
+            jsdom: {
+                url: "http://localhost/",
+            },
+        },
     },
 });


### PR DESCRIPTION
## Summary

- Install an isolated in-memory Web Storage implementation in the Vitest setup.
- Clear storage before every test and test that no value leaks from one test to the next.
- Set a stable jsdom URL, state the supported Node range, and add a Node 20.19/22/24 verification matrix.

## Validation

- npm ci
- npm test (72 passed, without NODE_OPTIONS)
- npm run lint
- npm run build:lib
- yamllint .github/workflows/verify.yml

Production persistence injection remains outside this test-environment-only change.