### PR TITLE
test: add deterministic component interaction harness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
     "name": "react-layman",
-    "version": "0.2.15",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "react-layman",
-            "version": "0.2.15",
-            "license": "ISC",
+            "version": "0.3.0",
+            "license": "MIT",
             "dependencies": {
                 "react-dnd": "^16.0.1",
                 "react-dnd-html5-backend": "^16.0.1"
             },
             "devDependencies": {
+                "@testing-library/react": "^16.3.2",
+                "@testing-library/user-event": "^14.6.4",
                 "@types/node": "^25.2.3",
                 "@types/react": "^18.2.66",
                 "@types/react-dom": "^18.2.22",
@@ -244,6 +246,22 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
@@ -254,10 +272,11 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2467,6 +2486,69 @@
                 "@swc/counter": "^0.1.3"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.6.4",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
+            "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.2",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2484,6 +2566,14 @@
             "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -3203,6 +3293,17 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
@@ -3687,6 +3788,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3740,6 +3852,14 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/entities": {
             "version": "4.5.0",
@@ -5601,6 +5721,17 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6051,6 +6182,44 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-format/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/prop-types": {
             "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
         "react-dnd-html5-backend": "^16.0.1"
     },
     "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.4",
         "@types/node": "^25.2.3",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",

--- a/src/FloatingWindow.tsx
+++ b/src/FloatingWindow.tsx
@@ -96,7 +96,12 @@ function FloatingWindowResizeHandles({data}: {data: FloatingWindowData}) {
             }}
         >
             {resizeHandles.map((dir) => (
-                <div key={dir} className={`layman-floating-resize ${dir}`} onMouseDown={startResize(dir)}></div>
+                <div
+                    key={dir}
+                    aria-label={`Resize floating window ${dir}`}
+                    className={`layman-floating-resize ${dir}`}
+                    onMouseDown={startResize(dir)}
+                ></div>
             ))}
         </div>
     );

--- a/src/WindowMenu.tsx
+++ b/src/WindowMenu.tsx
@@ -46,6 +46,7 @@ export function WindowMenu({path, position, tabs, selectedIndex, open, setOpen, 
         >
             <ToolbarButton
                 className="toolbar-button layman-window-menu-trigger"
+                aria-label="More window actions"
                 onClick={() => setOpen(!open)}
                 style={{width: buttonSize, height: buttonSize}}
             >
@@ -71,6 +72,7 @@ export function WindowMenu({path, position, tabs, selectedIndex, open, setOpen, 
                                 {mutable && (
                                     <button
                                         className="close-tab"
+                                        aria-label={`Close ${tab.name}`}
                                         onClick={() => layoutDispatch({type: "removeTab", path, tab})}
                                     >
                                         <CloseIcon />
@@ -81,6 +83,7 @@ export function WindowMenu({path, position, tabs, selectedIndex, open, setOpen, 
                     </div>
                     <div className="layman-window-menu-controls">
                         <ToolbarButton
+                            aria-label="Add tab"
                             onClick={() => {
                                 const newTab = new TabData("blank");
                                 layoutDispatch({type: "addTab", path, tab: newTab});

--- a/src/WindowTabs.tsx
+++ b/src/WindowTabs.tsx
@@ -44,7 +44,7 @@ export const Tab = ({tab, path, isSelected, onDelete, onMouseDown}: TabProps) =>
                 {renderTab(tab)}
             </button>
             {mutable && (
-                <button className="close-tab" onClick={onDelete}>
+                <button className="close-tab" aria-label={`Close ${tab.name}`} onClick={onDelete}>
                     <CloseIcon />
                 </button>
             )}
@@ -68,7 +68,7 @@ export const SingleTab = ({dragRef, tab, onDelete, onMouseDown}: SingleTabProps)
                 {renderTab(tab)}
             </button>
             {mutable && (
-                <button className="close-tab" onClick={onDelete}>
+                <button className="close-tab" aria-label={`Close ${tab.name}`} onClick={onDelete}>
                     <CloseIcon />
                 </button>
             )}

--- a/src/WindowToolbar.tsx
+++ b/src/WindowToolbar.tsx
@@ -293,6 +293,7 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
             return (
                 <ToolbarButton
                     key={index}
+                    aria-label={`Split ${placement}`}
                     onClick={() =>
                         layoutDispatch({
                             type: "addWindow",
@@ -315,7 +316,11 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
             case "maximize":
             case "minimize":
                 return (
-                    <ToolbarButton key={index} onClick={() => setMaximizedPath(isMaximized ? null : path)}>
+                    <ToolbarButton
+                        key={index}
+                        aria-label={isMaximized ? "Restore window" : "Maximize window"}
+                        onClick={() => setMaximizedPath(isMaximized ? null : path)}
+                    >
                         {isMaximized ? <MinimizeIcon /> : <MaximizeIcon />}
                     </ToolbarButton>
                 );
@@ -324,7 +329,11 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
             case "float":
             case "unfloat":
                 return (
-                    <ToolbarButton key={index} onClick={() => (isFloating ? unfloatWindow() : floatWindow())}>
+                    <ToolbarButton
+                        key={index}
+                        aria-label={isFloating ? "Dock window" : "Float window"}
+                        onClick={() => (isFloating ? unfloatWindow() : floatWindow())}
+                    >
                         {isFloating ? <UnfloatIcon /> : <FloatIcon />}
                     </ToolbarButton>
                 );
@@ -332,6 +341,7 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
                 return (
                     <ToolbarButton
                         key={index}
+                        aria-label="Close window"
                         onClick={() => {
                             layoutDispatch({
                                 type: "removeWindow",
@@ -344,7 +354,7 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
                 );
             case "misc":
                 return (
-                    <ToolbarButton key={index} onClick={() => {}}>
+                    <ToolbarButton key={index} aria-label="More window actions" onClick={() => {}}>
                         <EllipsisIcon />
                     </ToolbarButton>
                 );
@@ -437,6 +447,7 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
                     {/** Button to add a new blank tab */}
                     <div style={{display: "flex"}}>
                         <ToolbarButton
+                            aria-label="Add tab"
                             onClick={() => {
                                 const newTab = new TabData("blank");
                                 layoutDispatch({

--- a/tests/Layman.interaction.test.tsx
+++ b/tests/Layman.interaction.test.tsx
@@ -1,0 +1,91 @@
+import {fireEvent, screen, waitFor} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {expect, test} from "vitest";
+import {LaymanWindow} from "../src/types";
+import {
+    makeFloatingWindow,
+    makeTab,
+    makeTiledLayout,
+    makeWindow,
+    renderLayman,
+    setupComponentTestEnvironment,
+} from "./componentHarness";
+
+setupComponentTestEnvironment();
+
+const user = () => userEvent.setup();
+
+test("renders the null layout view", () => {
+    renderLayman();
+
+    expect(screen.getByText("Empty layout")).toBeTruthy();
+});
+
+test("selects a tab through the rendered toolbar", async () => {
+    const first = makeTab("First");
+    const second = makeTab("Second");
+    const {states} = renderLayman({initialLayout: makeTiledLayout(first, second)});
+
+    await user().click(screen.getByRole("button", {name: "Second"}));
+
+    await waitFor(() => {
+        const layout = states.at(-1)?.layout as LaymanWindow;
+        expect(layout.selectedIndex).toBe(1);
+    });
+    expect(screen.getByRole("region", {name: "Second pane"})).toBeTruthy();
+});
+
+test("closes a tab through the rendered toolbar", async () => {
+    const first = makeTab("First");
+    const second = makeTab("Second");
+    const {states} = renderLayman({initialLayout: makeTiledLayout(first, second), mutable: true});
+
+    await user().click(screen.getByRole("button", {name: "Close Second"}));
+
+    await waitFor(() => {
+        const layout = states.at(-1)?.layout as LaymanWindow;
+        expect(layout.tabs.map((tab) => tab.name)).toEqual(["First"]);
+    });
+    expect(screen.queryByRole("button", {name: "Second"})).toBeNull();
+});
+
+test("toggles a window between maximized and restored states", async () => {
+    const {states} = renderLayman({
+        initialLayout: makeTiledLayout(makeTab("Main")),
+        toolbarButtons: ["maximize"],
+    });
+
+    await user().click(screen.getByRole("button", {name: "Maximize window"}));
+    expect(screen.getByRole("button", {name: "Restore window"})).toBeTruthy();
+
+    await user().click(screen.getByRole("button", {name: "Restore window"}));
+    expect(screen.getByRole("button", {name: "Maximize window"})).toBeTruthy();
+    expect(states.at(-1)?.layout).toBeTruthy();
+});
+
+test("resizes a floating window with document mouse events", async () => {
+    const floating = makeFloatingWindow("floating-main", [makeTab("Floating")]);
+    const source = makeWindow(floating.tabs);
+    const {states} = renderLayman({
+        initialLayout: source,
+        actions: [
+            {
+                type: "moveWindow",
+                path: [],
+                newPath: {floatingId: floating.id},
+                window: source,
+                placement: "center",
+                position: floating.position,
+            },
+        ],
+    });
+
+    await waitFor(() => expect(states.at(-1)?.floatingWindows).toHaveLength(1));
+    fireEvent.mouseDown(screen.getByLabelText("Resize floating window e"), {clientX: 360, clientY: 140});
+    fireEvent.mouseMove(document, {clientX: 420, clientY: 140});
+    fireEvent.mouseUp(document);
+
+    await waitFor(() => {
+        expect(states.at(-1)?.floatingWindows[0].position.width).toBe(360);
+    });
+});

--- a/tests/componentHarness.tsx
+++ b/tests/componentHarness.tsx
@@ -1,0 +1,123 @@
+/* eslint-disable react-refresh/only-export-components -- Test-only provider helpers compose local capture components. */
+import {render, type RenderResult} from "@testing-library/react";
+import {useContext, useEffect, useRef} from "react";
+import {afterEach, beforeEach, vi} from "vitest";
+import {Layman} from "../src/Layman";
+import {LaymanContext, LaymanProvider} from "../src/LaymanContext";
+import {TabData} from "../src/TabData";
+import {
+    FloatingWindowData,
+    LaymanLayout,
+    LaymanLayoutAction,
+    LaymanState,
+    LaymanWindow,
+    Position,
+    ToolbarButtonType,
+} from "../src/types";
+
+const viewport = {top: 0, left: 0, width: 1280, height: 720};
+
+class TestResizeObserver {
+    constructor() {}
+
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+}
+
+export function setupComponentTestEnvironment() {
+    let uuid = 0;
+
+    beforeEach(() => {
+        uuid = 0;
+        vi.useRealTimers();
+        vi.stubGlobal("crypto", {randomUUID: () => `test-tab-${++uuid}`});
+        vi.stubGlobal("ResizeObserver", TestResizeObserver);
+        vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+            () => ({...viewport, x: viewport.left, y: viewport.top, right: viewport.width, bottom: viewport.height, toJSON: () => ({})}) as DOMRect
+        );
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+}
+
+export function makeTab(name: string) {
+    return new TabData(name);
+}
+
+export function makeWindow(tabs: TabData[], selectedIndex = 0): LaymanWindow {
+    return {tabs, selectedIndex};
+}
+
+export function makeTiledLayout(...tabs: TabData[]): LaymanLayout {
+    return makeWindow(tabs);
+}
+
+export function makeFloatingWindow(
+    id: string,
+    tabs: TabData[],
+    position: Position = {top: 40, left: 60, width: 300, height: 240}
+): FloatingWindowData {
+    return {id, tabs, selectedIndex: 0, position, zIndex: 1};
+}
+
+function StateCapture({onState}: {onState: (state: LaymanState) => void}) {
+    const {layout, floatingWindows} = useContext(LaymanContext);
+
+    useEffect(() => {
+        onState({layout, floatingWindows});
+    }, [floatingWindows, layout, onState]);
+
+    return null;
+}
+
+function InitialActions({actions}: {actions: LaymanLayoutAction[]}) {
+    const {layoutDispatch} = useContext(LaymanContext);
+    const dispatched = useRef(false);
+
+    useEffect(() => {
+        if (dispatched.current) return;
+        dispatched.current = true;
+        actions.forEach(layoutDispatch);
+    }, [actions, layoutDispatch]);
+
+    return null;
+}
+
+interface RenderLaymanOptions {
+    initialLayout?: LaymanLayout;
+    mutable?: boolean;
+    toolbarButtons?: ToolbarButtonType[];
+    actions?: LaymanLayoutAction[];
+}
+
+export interface RenderedLayman {
+    result: RenderResult;
+    states: LaymanState[];
+}
+
+export function renderLayman({initialLayout, mutable = false, toolbarButtons = [], actions = []}: RenderLaymanOptions = {}): RenderedLayman {
+    const states: LaymanState[] = [];
+    const result = render(
+        <LaymanProvider
+            initialLayout={initialLayout}
+            mutable={mutable}
+            toolbarButtons={toolbarButtons}
+            renderTab={(tab) => tab.name}
+            renderPane={(tab) => <section aria-label={`${tab.name} pane`}>{tab.name} pane</section>}
+            renderNull={<p>Empty layout</p>}
+        >
+            <StateCapture onState={(state) => states.push(state)} />
+            <InitialActions actions={actions} />
+            <Layman />
+        </LaymanProvider>
+    );
+
+    return {result, states};
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     test: {
         environment: "jsdom",
         globals: true,
-        include: ["tests/**/*.test.ts"],
+        include: ["tests/**/*.test.{ts,tsx}"],
     },
 });


### PR DESCRIPTION
## Summary
- add React Testing Library and user-event with a small shared Layman provider harness
- cover empty, tab selection, close, maximize/restore, and floating resize interactions
- add accessible names for icon-only controls used by the tests

## Validation
- `npx vitest run tests/Layman.interaction.test.tsx --pool=threads --maxWorkers=1`
- `NODE_OPTIONS="--localstorage-file=/tmp/react-layman-vitest-localstorage" npm test` (75 passed)
- `npm run lint -- --max-warnings=0`
- strict TypeScript check of the two new test files
- `npm run build:lib`

## Dependency
This PR follows #29 for Node 26 portable `localStorage` test setup. On upstream `main`, plain `npm test` has the pre-existing persistence-suite failure; this PR does not duplicate that setup change.