### PR TITLE
fix: scope portal and measurements to each Layman view

### DIFF
--- a/src/FloatingDockZones.tsx
+++ b/src/FloatingDockZones.tsx
@@ -6,6 +6,8 @@ import {findWindowRectAtPoint} from "./layoutGeometry";
 import {DragData, LaymanPath, Position} from "./types";
 import {isFloatingAddress} from "./utils";
 import {BottomSplitIcon, LeftSplitIcon, RightSplitIcon, TopSplitIcon, UnfloatIcon} from "./Icons";
+import {useLaymanView} from "./LaymanViewContext";
+import {readLaymanStyleNumber} from "./viewMetrics";
 
 // Fixed pixel sizes for the drop-zone overlays shown while dragging a floating
 // window. These are deliberately constant (not relative to container size) so
@@ -25,9 +27,7 @@ const EDGE_ICONS: Record<Edge, () => JSX.Element> = {
 };
 
 /** Computes the container-relative rect for one of the 4 fixed edge zones. */
-function edgeZoneRect(edge: Edge, container: {width: number; height: number}): Position {
-    const inset =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--anchor-inset").trim(), 10) || 16;
+function edgeZoneRect(edge: Edge, container: {width: number; height: number}, inset: number): Position {
     switch (edge) {
         case "top":
             return {top: inset, left: (container.width - EDGE_LONG) / 2, width: EDGE_LONG, height: EDGE_SHORT};
@@ -53,7 +53,7 @@ function edgeZoneRect(edge: Edge, container: {width: number; height: number}): P
 /** One of the 4 fixed edge zones: docks the dragged floating window at the
  *  root of the layout, on that edge (splitting the root only if it isn't
  *  already a matching-direction split - see `treeAddWindow`). */
-function FloatingEdgeZone({edge, container}: {edge: Edge; container: {width: number; height: number}}) {
+function FloatingEdgeZone({edge, container, inset}: {edge: Edge; container: {width: number; height: number}; inset: number}) {
     const {layoutDispatch} = useContext(LaymanContext);
     const [{isOver}, drop] = useDrop<DragData, void, {isOver: boolean}>(() => ({
         accept: [WindowType],
@@ -75,7 +75,7 @@ function FloatingEdgeZone({edge, container}: {edge: Edge; container: {width: num
         <div
             ref={drop}
             className={`layman-floating-anchor ${edge} ${isOver ? "over" : ""}`}
-            style={{position: "absolute", ...edgeZoneRect(edge, container)}}
+            style={{position: "absolute", ...edgeZoneRect(edge, container, inset)}}
         >
             <Icon />
         </div>
@@ -134,6 +134,8 @@ function FloatingCenterZone({path, position}: {path: LaymanPath; position: Posit
  */
 export function FloatingDockZones() {
     const {layout, globalContainerSize, maxDepth} = useContext(LaymanContext);
+    const {rootRef} = useLaymanView();
+    const inset = readLaymanStyleNumber(rootRef.current, "--anchor-inset", 16);
 
     const {isDraggingFloat, clientOffset} = useDragLayer((monitor) => {
         const itemType = monitor.getItemType();
@@ -157,10 +159,10 @@ export function FloatingDockZones() {
         <>
             {maxDepth > 0 && (
                 <>
-                    <FloatingEdgeZone edge="top" container={globalContainerSize} />
-                    <FloatingEdgeZone edge="bottom" container={globalContainerSize} />
-                    <FloatingEdgeZone edge="left" container={globalContainerSize} />
-                    <FloatingEdgeZone edge="right" container={globalContainerSize} />
+                    <FloatingEdgeZone edge="top" container={globalContainerSize} inset={inset} />
+                    <FloatingEdgeZone edge="bottom" container={globalContainerSize} inset={inset} />
+                    <FloatingEdgeZone edge="left" container={globalContainerSize} inset={inset} />
+                    <FloatingEdgeZone edge="right" container={globalContainerSize} inset={inset} />
                 </>
             )}
             {hovered && <FloatingCenterZone path={hovered.path} position={hovered.position} />}

--- a/src/Layman.tsx
+++ b/src/Layman.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useMemo, useRef} from "react";
+import {useCallback, useContext, useEffect, useMemo, useRef, useState} from "react";
 import {WindowToolbar} from "./WindowToolbar";
 import {Window} from "./Window";
 import {LaymanLayout, LaymanPath, ToolBarProps, WindowProps, Position, SeparatorProps} from "./types";
@@ -7,34 +7,35 @@ import {Separator} from "./Separator";
 import {addressKey} from "./utils";
 import {FloatingResizeHandleLayer} from "./FloatingWindow";
 import {FloatingDockZones} from "./FloatingDockZones";
+import {LaymanViewScope} from "./LaymanViewContext";
+import {measureLaymanRoot} from "./viewMetrics";
 
 /**
  * Entry point for Layman Window Manager
  */
 export function Layman() {
-    const {globalContainerSize, setGlobalContainerSize, layout, renderNull, draggedWindowTabs, floatingWindows} =
+    const {viewId, globalContainerSize, setGlobalContainerSize, layout, renderNull, draggedWindowTabs, floatingWindows} =
         useContext(LaymanContext);
     // Reference for parent div
     const laymanRef = useRef<HTMLDivElement | null>(null);
+    const [dragBorderElement, setDragBorderElement] = useState<HTMLDivElement | null>(null);
+
+    const updateContainerSize = useCallback(() => {
+        const position = measureLaymanRoot(laymanRef.current);
+        if (position) setGlobalContainerSize(position);
+    }, [setGlobalContainerSize]);
 
     // Keep the shared container size in context up to date on window resize,
     // since layout math throughout Layman is expressed in absolute pixels
     // derived from this size rather than percentages.
     useEffect(() => {
-        const updateContainerSize = () => {
-            if (laymanRef.current) {
-                const {top, left, width, height} = laymanRef.current.getBoundingClientRect();
-                setGlobalContainerSize({top, left, width, height});
-            }
-        };
-
         updateContainerSize();
         window.addEventListener("resize", updateContainerSize);
 
         return () => {
             window.removeEventListener("resize", updateContainerSize);
         };
-    }, [setGlobalContainerSize]);
+    }, [updateContainerSize]);
 
     // Window resize alone doesn't catch every case (e.g. the container growing
     // because a flex/grid parent changed), so a ResizeObserver watches the
@@ -43,19 +44,14 @@ export function Layman() {
         if (!laymanRef.current) return;
         const laymanContainer = laymanRef.current;
 
-        const resizeObserver = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-                const {top, left, width, height} = entry.target.getBoundingClientRect();
-                setGlobalContainerSize({top, left, width, height});
-            }
-        });
+        const resizeObserver = new ResizeObserver(updateContainerSize);
 
         resizeObserver.observe(laymanContainer);
 
         return () => {
             resizeObserver.disconnect();
         };
-    }, [globalContainerSize, laymanRef, setGlobalContainerSize]);
+    }, [updateContainerSize]);
 
     // Derive component lists from layout
     const {toolbars, windows, separators} = useMemo(() => {
@@ -263,29 +259,32 @@ export function Layman() {
     }, [globalContainerSize, draggedWindowTabs, layout, floatingWindows]);
 
     return (
-        <div ref={laymanRef} className="layman-root">
-            {/* Shown behind any floating windows when the tree is empty. */}
-            {!layout && renderNull}
-            {toolbars.map((props) => (
-                <WindowToolbar key={addressKey(props.path)} {...props} />
-            ))}
-            {windows.map((props) => (
-                <Window key={props.tab.id} {...props} />
-            ))}
-            {separators.map((props) => (
-                <Separator
-                    key={props.path.length != 0 ? props.path.join(":") : "root"}
-                    separators={separators} // Pass the full list
-                    {...props}
-                />
-            ))}
-            {/* Resize handles for floating windows (their toolbar/pane render
+        <LaymanViewScope rootRef={laymanRef} dragBorderElement={dragBorderElement}>
+            <div ref={laymanRef} className="layman-root" data-layman-view={viewId}>
+                <div ref={setDragBorderElement} className="layman-drag-window-border"></div>
+                {/* Shown behind any floating windows when the tree is empty. */}
+                {!layout && renderNull}
+                {toolbars.map((props) => (
+                    <WindowToolbar key={addressKey(props.path)} {...props} />
+                ))}
+                {windows.map((props) => (
+                    <Window key={props.tab.id} {...props} />
+                ))}
+                {separators.map((props) => (
+                    <Separator
+                        key={props.path.length != 0 ? props.path.join(":") : "root"}
+                        separators={separators} // Pass the full list
+                        {...props}
+                    />
+                ))}
+                {/* Resize handles for floating windows (their toolbar/pane render
                 via the flat lists above, identically to tiled windows). */}
-            <FloatingResizeHandleLayer />
-            {/* Dock zones for floating-window whole-window drags (edges of
+                <FloatingResizeHandleLayer />
+                {/* Dock zones for floating-window whole-window drags (edges of
                 the root + the tiled window under the cursor); renders
                 nothing unless such a drag is in progress. */}
-            <FloatingDockZones />
-        </div>
+                <FloatingDockZones />
+            </div>
+        </LaymanViewScope>
     );
 }

--- a/src/LaymanContext.tsx
+++ b/src/LaymanContext.tsx
@@ -15,8 +15,19 @@ import {TabData} from "./TabData";
 import {LaymanReducer} from "./LaymanReducer";
 import {loadState, saveState} from "./persistence";
 
+let generatedViewCount = 0;
+
+function createViewId() {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return `layman-${crypto.randomUUID()}`;
+    }
+    generatedViewCount += 1;
+    return `layman-${generatedViewCount}`;
+}
+
 // Define default values for the context
 const defaultContextValue: LaymanContextType = {
+    viewId: "layman-unmounted",
     globalContainerSize: {top: 0, left: 0, width: 0, height: 0},
     setGlobalContainerSize: () => {},
     layout: {tabs: []},
@@ -52,6 +63,8 @@ type LaymanProviderProps = {
     maxDepth?: number;
     // Show/hide the window tab row. Default: true.
     showTabs?: boolean;
+    // Optional diagnostic and DOM-isolation ID. Generated once when omitted.
+    viewId?: string;
     children: React.ReactNode;
 };
 
@@ -67,8 +80,12 @@ export const LaymanProvider = ({
     storageKey,
     maxDepth = Infinity,
     showTabs = true,
+    viewId,
     children,
 }: LaymanProviderProps) => {
+    const generatedViewId = useRef<string | null>(null);
+    if (generatedViewId.current === null) generatedViewId.current = createViewId();
+    const resolvedViewId = viewId ?? generatedViewId.current;
     const [{layout, floatingWindows}, layoutDispatch] = useReducer(
         LaymanReducer,
         {layout: initialLayout, floatingWindows: []},
@@ -118,6 +135,7 @@ export const LaymanProvider = ({
     return (
         <LaymanContext.Provider
             value={{
+                viewId: resolvedViewId,
                 globalContainerSize,
                 setGlobalContainerSize,
                 layout,
@@ -143,7 +161,6 @@ export const LaymanProvider = ({
         >
             <DndProvider backend={HTML5Backend}>
                 <DropHighlight position={dropHighlightPosition} isDragging={globalDragging} />
-                <div id="drag-window-border"></div>
                 {children}
             </DndProvider>
         </LaymanContext.Provider>

--- a/src/LaymanViewContext.tsx
+++ b/src/LaymanViewContext.tsx
@@ -1,0 +1,23 @@
+import {createContext, ReactNode, RefObject, useContext} from "react";
+
+interface LaymanViewContextValue {
+    rootRef: RefObject<HTMLDivElement>;
+    dragBorderElement: HTMLDivElement | null;
+}
+
+const LaymanViewContext = createContext<LaymanViewContextValue | null>(null);
+
+export function LaymanViewScope({
+    rootRef,
+    dragBorderElement,
+    children,
+}: LaymanViewContextValue & {children: ReactNode}) {
+    return <LaymanViewContext.Provider value={{rootRef, dragBorderElement}}>{children}</LaymanViewContext.Provider>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- Internal hook shares the private view context.
+export function useLaymanView() {
+    const view = useContext(LaymanViewContext);
+    if (!view) throw new Error("Layman view components must render inside Layman.");
+    return view;
+}

--- a/src/Separator.tsx
+++ b/src/Separator.tsx
@@ -2,17 +2,18 @@ import {MouseEventHandler, useContext, useEffect, useState} from "react";
 import {LaymanContext} from "./LaymanContext";
 import {deepEqual} from "./utils";
 import {SeparatorProps} from "./types";
+import {useLaymanView} from "./LaymanViewContext";
+import {readLaymanStyleNumber} from "./viewMetrics";
 
 export function Separator({nodePosition, position, index, direction, path, separators}: SeparatorProps) {
     const {globalContainerSize, layoutDispatch} = useContext(LaymanContext);
+    const {rootRef} = useLaymanView();
     const [isDragging, setIsDragging] = useState(false);
 
     // parseInt returns NaN (not null/undefined) when the CSS variable is missing,
     // so the fallback must use || rather than ?? to actually take effect.
-    const separatorThickness =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--separator-thickness").trim(), 10) || 8;
-    const toolbarHeight =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--toolbar-height").trim(), 10) || 32;
+    const separatorThickness = readLaymanStyleNumber(rootRef.current, "--separator-thickness", 8);
+    const toolbarHeight = readLaymanStyleNumber(rootRef.current, "--toolbar-height", 32);
 
     const previousSeparator = separators!.find((sep) => {
         const prevPath = [...path];

--- a/src/Window.tsx
+++ b/src/Window.tsx
@@ -5,6 +5,8 @@ import {createPortal} from "react-dom";
 import {WindowContext} from "./WindowContext";
 import {Position, WindowProps} from "./types";
 import {deepEqual, isFloatingAddress} from "./utils";
+import {useLaymanView} from "./LaymanViewContext";
+import {readLaymanStyleNumber} from "./viewMetrics";
 
 export function Window({position: rawPosition, path, tab, isSelected, zIndex: floatingZIndex}: WindowProps) {
     const {
@@ -16,19 +18,17 @@ export function Window({position: rawPosition, path, tab, isSelected, zIndex: fl
         showTabs,
         layoutDispatch,
     } = useContext(LaymanContext);
+    const {dragBorderElement, rootRef} = useLaymanView();
 
     const isFloating = isFloatingAddress(path);
 
     // parseInt returns NaN (not null/undefined) when the CSS variable is missing,
     // so the fallback must use || rather than ?? to actually take effect.
-    const separatorThickness =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--separator-thickness").trim(), 10) || 8;
+    const separatorThickness = readLaymanStyleNumber(rootRef.current, "--separator-thickness", 8);
 
     // When the tab row is hidden the toolbar takes no vertical space, so the pane
     // fills the entire window region.
-    const windowToolbarHeight = showTabs
-        ? parseInt(getComputedStyle(document.documentElement).getPropertyValue("--toolbar-height").trim(), 10) || 64
-        : 0;
+    const windowToolbarHeight = showTabs ? readLaymanStyleNumber(rootRef.current, "--toolbar-height", 64) : 0;
 
     // A maximized window overrides its layout position to fill the whole container.
     const isMaximized = maximizedPath !== null && deepEqual(maximizedPath, path);
@@ -73,19 +73,7 @@ export function Window({position: rawPosition, path, tab, isSelected, zIndex: fl
         }
     }, [clientOffset, isDragging, windowDragStartPosition.x, windowDragStartPosition.y]);
 
-    const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
-
-    // Check for the portal target element when the component mounts
-    useEffect(() => {
-        const element = document.getElementById("drag-window-border");
-        if (element) {
-            setPortalElement(element);
-        } else {
-            console.error("Element with id 'drag-window-border' not found.");
-        }
-    }, []);
-
-    if (!portalElement) {
+    if (!dragBorderElement) {
         return null; // Don't render until portal element is available
     }
 
@@ -142,7 +130,7 @@ export function Window({position: rawPosition, path, tab, isSelected, zIndex: fl
                             userSelect: "none",
                         }}
                     ></div>,
-                    document.getElementById("drag-window-border")!
+                    dragBorderElement
                 )}
             <WindowContext.Provider
                 value={{

--- a/src/WindowDropTarget.tsx
+++ b/src/WindowDropTarget.tsx
@@ -4,6 +4,8 @@ import {useContext, useEffect, useRef} from "react";
 import {LaymanContext} from "./LaymanContext";
 import {DragData, Position, WindowAddress} from "./types";
 import {isFloatingAddress} from "./utils";
+import {useLaymanView} from "./LaymanViewContext";
+import {readLaymanStyleNumber} from "./viewMetrics";
 
 interface WindowDropTargetProps {
     path: WindowAddress;
@@ -14,6 +16,7 @@ interface WindowDropTargetProps {
 export function WindowDropTarget({path, position, placement}: WindowDropTargetProps) {
     const {globalContainerSize, layoutDispatch, setDropHighlightPosition, maxDepth, showTabs} =
         useContext(LaymanContext);
+    const {rootRef} = useLaymanView();
     const newDropHighlightPosition = useRef<Position>({
         top: 0,
         left: 0,
@@ -26,14 +29,11 @@ export function WindowDropTarget({path, position, placement}: WindowDropTargetPr
     // every placement behaves like "center" there and is always allowed.
     const wouldExceedMaxDepth = placement !== "center" && !isFloatingAddress(path) && path.length >= maxDepth;
 
-    const windowToolbarHeight = showTabs
-        ? parseInt(getComputedStyle(document.documentElement).getPropertyValue("--toolbar-height").trim(), 10) || 64
-        : 0;
+    const windowToolbarHeight = showTabs ? readLaymanStyleNumber(rootRef.current, "--toolbar-height", 64) : 0;
 
     // parseInt returns NaN (not null/undefined) when the CSS variable is missing,
     // so the fallback must use || rather than ?? to actually take effect.
-    const separatorThickness =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--separator-thickness").trim(), 10) || 8;
+    const separatorThickness = readLaymanStyleNumber(rootRef.current, "--separator-thickness", 8);
 
     useEffect(() => {
         const dropPosition: Position = {

--- a/src/WindowMenu.tsx
+++ b/src/WindowMenu.tsx
@@ -4,6 +4,8 @@ import {ToolbarButton} from "./ToolbarButton";
 import {TabData} from "./TabData";
 import {AddIcon, CloseIcon, EllipsisIcon} from "./Icons";
 import {Position, WindowAddress} from "./types";
+import {useLaymanView} from "./LaymanViewContext";
+import {readLaymanStyleNumber} from "./viewMetrics";
 
 interface WindowMenuProps {
     path: WindowAddress;
@@ -24,13 +26,12 @@ interface WindowMenuProps {
  */
 export function WindowMenu({path, position, tabs, selectedIndex, open, setOpen, controlButtons}: WindowMenuProps) {
     const {layoutDispatch, renderTab, mutable} = useContext(LaymanContext);
+    const {rootRef} = useLaymanView();
 
     // parseInt returns NaN (not null/undefined) when the CSS variable is missing,
     // so the fallback must use || rather than ?? to actually take effect.
-    const cssToolbarHeight =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--toolbar-height").trim(), 10) || 64;
-    const separatorThickness =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--separator-thickness").trim(), 10) || 8;
+    const cssToolbarHeight = readLaymanStyleNumber(rootRef.current, "--toolbar-height", 64);
+    const separatorThickness = readLaymanStyleNumber(rootRef.current, "--separator-thickness", 8);
 
     const buttonSize = cssToolbarHeight;
 

--- a/src/WindowToolbar.tsx
+++ b/src/WindowToolbar.tsx
@@ -23,6 +23,8 @@ import {
     UnfloatIcon,
 } from "./Icons";
 import {addressKey, deepEqual, isFloatingAddress} from "./utils";
+import {useLaymanView} from "./LaymanViewContext";
+import {readLaymanStyleNumber} from "./viewMetrics";
 
 function usePrevious(value: number) {
     const ref = useRef(0);
@@ -47,6 +49,7 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
         maxDepth,
         showTabs,
     } = useContext(LaymanContext);
+    const {rootRef} = useLaymanView();
     const tabContainerRef = useRef<HTMLDivElement>(null);
     const isFloating = isFloatingAddress(path);
     // A maximized window overrides its layout position to fill the whole container.
@@ -60,12 +63,10 @@ export function WindowToolbar({path, position: rawPosition, tabs, selectedIndex,
     const previousTabCount = usePrevious(tabs.length);
     // parseInt returns NaN (not null/undefined) when the CSS variable is missing,
     // so the fallback must use || rather than ?? to actually take effect.
-    const cssToolbarHeight =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--toolbar-height").trim(), 10) || 64;
+    const cssToolbarHeight = readLaymanStyleNumber(rootRef.current, "--toolbar-height", 64);
     // When the tab row is hidden the toolbar occupies no vertical space.
     const windowToolbarHeight = showTabs ? cssToolbarHeight : 0;
-    const separatorThickness =
-        parseInt(getComputedStyle(document.documentElement).getPropertyValue("--separator-thickness").trim(), 10) || 8;
+    const separatorThickness = readLaymanStyleNumber(rootRef.current, "--separator-thickness", 8);
     // Splits create a deeper window (path.length + 1); block them at the limit.
     // Floating windows are always single-pane, so splitting never applies.
     const atMaxDepth = isFloating || path.length >= maxDepth;

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,7 @@ export type ToolbarButtonType =
     | "misc";
 
 export interface LaymanContextType {
+    viewId: string;
     globalContainerSize: Position;
     setGlobalContainerSize: Dispatch<SetStateAction<Position>>;
     layout: LaymanLayout;

--- a/src/viewMetrics.ts
+++ b/src/viewMetrics.ts
@@ -1,0 +1,13 @@
+import {Position} from "./types";
+
+export function measureLaymanRoot(root: HTMLElement | null): Position | null {
+    if (!root) return null;
+    const {top, left, width, height} = root.getBoundingClientRect();
+    return {top, left, width, height};
+}
+
+export function readLaymanStyleNumber(root: HTMLElement | null, name: string, fallback: number): number {
+    if (!root) return fallback;
+    const value = Number.parseInt(window.getComputedStyle(root).getPropertyValue(name).trim(), 10);
+    return Number.isFinite(value) ? value : fallback;
+}

--- a/tests/viewIsolation.test.ts
+++ b/tests/viewIsolation.test.ts
@@ -1,0 +1,131 @@
+import {createElement} from "react";
+import {act} from "react-dom/test-utils";
+import {createRoot, Root} from "react-dom/client";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {Layman} from "../src/Layman";
+import {LaymanProvider} from "../src/LaymanContext";
+import {TabData} from "../src/TabData";
+import {Position} from "../src/types";
+
+const rects: Record<string, Position> = {
+    alpha: {top: 10, left: 20, width: 320, height: 240},
+    beta: {top: 30, left: 40, width: 640, height: 480},
+};
+
+class TestResizeObserver {
+    static instances: TestResizeObserver[] = [];
+    target: Element | null = null;
+    disconnected = false;
+
+    constructor(private readonly callback: ResizeObserverCallback) {
+        TestResizeObserver.instances.push(this);
+    }
+
+    observe(target: Element) {
+        this.target = target;
+    }
+
+    disconnect() {
+        this.disconnected = true;
+    }
+
+    static emit(target: Element) {
+        const observer = TestResizeObserver.instances.find((candidate) => candidate.target === target);
+        if (!observer) throw new Error("Missing observer for Layman view.");
+        observer.callback([{target} as ResizeObserverEntry], observer as unknown as ResizeObserver);
+    }
+}
+
+const mountedRoots: Root[] = [];
+
+function renderView(viewId: string) {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    mountedRoots.push(root);
+    const tab = new TabData(viewId);
+
+    act(() => {
+        root.render(
+            createElement(
+                LaymanProvider,
+                {
+                    initialLayout: {tabs: [tab], selectedIndex: 0},
+                    renderPane: (pane) => createElement("p", null, pane.name),
+                    renderTab: (tabData) => tabData.name,
+                    renderNull: createElement("p", null, "Empty"),
+                    viewId,
+                },
+                createElement(Layman)
+            )
+        );
+    });
+
+    const view = container.querySelector(`[data-layman-view="${viewId}"]`);
+    if (!view) throw new Error(`Missing ${viewId} view.`);
+    return view as HTMLElement;
+}
+
+beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+        const viewId = this.getAttribute("data-layman-view");
+        const rect = rects[viewId ?? ""] ?? {top: 0, left: 0, width: 0, height: 0};
+        return {
+            ...rect,
+            x: rect.left,
+            y: rect.top,
+            right: rect.left + rect.width,
+            bottom: rect.top + rect.height,
+            toJSON: () => ({}),
+        } as DOMRect;
+    });
+    vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+        const viewId = element.getAttribute("data-layman-view");
+        const toolbarHeight = viewId === "alpha" ? "40px" : "72px";
+        return {getPropertyValue: (name) => (name === "--toolbar-height" ? toolbarHeight : "")} as CSSStyleDeclaration;
+    });
+});
+
+afterEach(() => {
+    mountedRoots.splice(0).forEach((root) => act(() => root.unmount()));
+    TestResizeObserver.instances = [];
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.replaceChildren();
+});
+
+describe("Layman view isolation", () => {
+    it("scopes portals, style tokens, measurements, and observer cleanup to each view", () => {
+        const alpha = renderView("alpha");
+        const beta = renderView("beta");
+
+        expect(document.querySelectorAll("#drag-window-border")).toHaveLength(0);
+        expect(alpha.querySelector(".layman-drag-window-border")).toBeTruthy();
+        expect(beta.querySelector(".layman-drag-window-border")).toBeTruthy();
+        expect(alpha.querySelector(".layman-drag-window-border")).not.toBe(
+            beta.querySelector(".layman-drag-window-border")
+        );
+        expect(alpha.querySelector<HTMLElement>(".layman-toolbar")?.style).toMatchObject({
+            width: "312px",
+            height: "40px",
+        });
+        expect(beta.querySelector<HTMLElement>(".layman-toolbar")?.style).toMatchObject({
+            width: "632px",
+            height: "72px",
+        });
+        expect(TestResizeObserver.instances).toHaveLength(2);
+
+        rects.alpha = {...rects.alpha, width: 480};
+        act(() => TestResizeObserver.emit(alpha));
+        expect(alpha.querySelector<HTMLElement>(".layman-toolbar")?.style.width).toBe("472px");
+        expect(beta.querySelector<HTMLElement>(".layman-toolbar")?.style.width).toBe("632px");
+        expect(TestResizeObserver.instances).toHaveLength(2);
+
+        const [alphaObserver, betaObserver] = TestResizeObserver.instances;
+        act(() => mountedRoots.shift()?.unmount());
+        expect(alphaObserver.disconnected).toBe(true);
+        expect(betaObserver.disconnected).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- give each rendered Layman root a generated or supplied `data-layman-view` identity
- keep its drag-border portal, measurements, and CSS-token reads inside that root
- subscribe the resize observer once per root and disconnect it on unmount

## Validation
- `npx vitest run tests/viewIsolation.test.ts --pool=threads --maxWorkers=1`
- `NODE_OPTIONS="--localstorage-file=/tmp/react-layman-vitest-localstorage" npm test` (71 passed)
- `npm run lint -- --max-warnings=0`
- `npx tsc --noEmit`
- `npm run build:lib`

## Dependency
Plain Node 26 `npm test` becomes portable when #29 lands. This PR is otherwise independently applicable to `main` and does not expose DOM handles through the public API.